### PR TITLE
refactor: port Firo watcher from RPC to ElectrumX

### DIFF
--- a/.changeset/broad-cats-fetch.md
+++ b/.changeset/broad-cats-fetch.md
@@ -1,0 +1,5 @@
+---
+'@rosen-bridge/watcher': minor
+---
+
+Port Firo watcher from firod JSON-RPC to ElectrumX TCP connector

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -78,15 +78,14 @@ binance:
     timeout: 10 # rpc request timeout (in seconds)
     # authToken: # rpc auth token
 firo:
-  type: '' # options: rpc
+  type: '' # options: electrumx
   initial:
     height: -1 # initial height of scanning
   interval: 180 # scanning interval (in seconds)
-  rpc:
-    url: '' # rpc url
-    timeout: 10 # rpc request timeout (in seconds)
-    # username: '' # rpc username for authentication required instances
-    # password: '' # rpc password for authentication required instances
+  electrumx:
+    host: '' # electrumx host
+    port: 50001 # electrumx port
+    timeout: 10 # electrumx request timeout (in seconds)
 ergo:
   network: 'Mainnet' # ergo network type. testnet or mainnet
   type: 'node' # ergo scanner type. options: node, explorer

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -90,6 +90,7 @@ firo:
   electrumx:
     host: '' # electrumx host
     port: 50002 # electrumx SSL port
+    reconnectDelay: 5 # electrumx reconnect delay on socket close (in seconds)
     timeout: 10 # electrumx request timeout (in seconds)
 ergo:
   network: 'Mainnet' # ergo network type. testnet or mainnet

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -84,7 +84,7 @@ firo:
   interval: 180 # scanning interval (in seconds)
   electrumx:
     host: '' # electrumx host
-    port: 50001 # electrumx port
+    port: 50002 # electrumx SSL port
     timeout: 10 # electrumx request timeout (in seconds)
 ergo:
   network: 'Mainnet' # ergo network type. testnet or mainnet

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -78,10 +78,15 @@ binance:
     timeout: 10 # rpc request timeout (in seconds)
     # authToken: # rpc auth token
 firo:
-  type: '' # options: electrumx
+  type: '' # options: rpc, electrumx
   initial:
     height: -1 # initial height of scanning
   interval: 180 # scanning interval (in seconds)
+  rpc:
+    url: '' # rpc url
+    timeout: 10 # rpc request timeout (in seconds)
+    # username: '' # rpc username for authentication required instances
+    # password: '' # rpc password for authentication required instances
   electrumx:
     host: '' # electrumx host
     port: 50002 # electrumx SSL port

--- a/docker/custom-environment-variables.yaml
+++ b/docker/custom-environment-variables.yaml
@@ -31,14 +31,9 @@ binance:
   rpc:
     authToken: 'BINANCE_RPC_AUTH_TOKEN'
 firo:
-  type: 'FIRO_TYPE'
   rpc:
-    url: 'FIRO_RPC_URL'
-    timeout: 'FIRO_RPC_TIMEOUT'
     username: 'FIRO_RPC_USERNAME'
     password: 'FIRO_RPC_PASSWORD'
   electrumx:
-    host: 'FIRO_ELECTRUMX_HOST'
     port: 'FIRO_ELECTRUMX_PORT'
-    timeout: 'FIRO_ELECTRUMX_TIMEOUT'
 overrideLokiBasicAuth: 'OVERRIDE_LOKI_BASIC_AUTH'

--- a/docker/custom-environment-variables.yaml
+++ b/docker/custom-environment-variables.yaml
@@ -31,6 +31,12 @@ binance:
   rpc:
     authToken: 'BINANCE_RPC_AUTH_TOKEN'
 firo:
+  type: 'FIRO_TYPE'
+  rpc:
+    url: 'FIRO_RPC_URL'
+    timeout: 'FIRO_RPC_TIMEOUT'
+    username: 'FIRO_RPC_USERNAME'
+    password: 'FIRO_RPC_PASSWORD'
   electrumx:
     host: 'FIRO_ELECTRUMX_HOST'
     port: 'FIRO_ELECTRUMX_PORT'

--- a/docker/custom-environment-variables.yaml
+++ b/docker/custom-environment-variables.yaml
@@ -31,7 +31,8 @@ binance:
   rpc:
     authToken: 'BINANCE_RPC_AUTH_TOKEN'
 firo:
-  rpc:
-    username: 'FIRO_RPC_USERNAME'
-    password: 'FIRO_RPC_PASSWORD'
+  electrumx:
+    host: 'FIRO_ELECTRUMX_HOST'
+    port: 'FIRO_ELECTRUMX_PORT'
+    timeout: 'FIRO_ELECTRUMX_TIMEOUT'
 overrideLokiBasicAuth: 'OVERRIDE_LOKI_BASIC_AUTH'

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -612,6 +612,12 @@ class FiroConfig {
   type: string;
   initialHeight: number;
   interval: number;
+  rpc?: {
+    url: string;
+    timeout: number;
+    username?: string;
+    password?: string;
+  };
   electrumx?: {
     host: string;
     port: number;
@@ -623,14 +629,20 @@ class FiroConfig {
     if (network === Constants.FIRO_CHAIN_NAME) {
       this.initialHeight = getRequiredNumber('firo.initial.height');
       this.interval = getRequiredNumber('firo.interval');
-      if (this.type === Constants.ELECTRUMX_TYPE) {
+      if (this.type === Constants.RPC_TYPE) {
+        const url = getRequiredString('firo.rpc.url');
+        const timeout = getRequiredNumber('firo.rpc.timeout');
+        const username = getOptionalString('firo.rpc.username', undefined);
+        const password = getOptionalString('firo.rpc.password', undefined);
+        this.rpc = { url, timeout, username, password };
+      } else if (this.type === Constants.ELECTRUMX_TYPE) {
         const host = getRequiredString('firo.electrumx.host');
         const port = getRequiredNumber('firo.electrumx.port');
         const timeout = getRequiredNumber('firo.electrumx.timeout');
         this.electrumx = { host, port, timeout };
       } else {
         throw new Error(
-          `Improperly configured. firo configuration type is invalid available choices are '${Constants.ELECTRUMX_TYPE}'`
+          `Improperly configured. firo configuration type is invalid available choices are '${Constants.RPC_TYPE}', '${Constants.ELECTRUMX_TYPE}'`
         );
       }
     }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -612,11 +612,10 @@ class FiroConfig {
   type: string;
   initialHeight: number;
   interval: number;
-  rpc?: {
-    url: string;
+  electrumx?: {
+    host: string;
+    port: number;
     timeout: number;
-    username?: string;
-    password?: string;
   };
 
   constructor(network: string) {
@@ -624,15 +623,14 @@ class FiroConfig {
     if (network === Constants.FIRO_CHAIN_NAME) {
       this.initialHeight = getRequiredNumber('firo.initial.height');
       this.interval = getRequiredNumber('firo.interval');
-      if (this.type === Constants.RPC_TYPE) {
-        const url = getRequiredString('firo.rpc.url');
-        const timeout = getRequiredNumber('firo.rpc.timeout');
-        const username = getOptionalString('firo.rpc.username', undefined);
-        const password = getOptionalString('firo.rpc.password', undefined);
-        this.rpc = { url, timeout, username, password };
+      if (this.type === Constants.ELECTRUMX_TYPE) {
+        const host = getRequiredString('firo.electrumx.host');
+        const port = getRequiredNumber('firo.electrumx.port');
+        const timeout = getRequiredNumber('firo.electrumx.timeout');
+        this.electrumx = { host, port, timeout };
       } else {
         throw new Error(
-          `Improperly configured. firo configuration type is invalid available choices are '${Constants.RPC_TYPE}'`
+          `Improperly configured. firo configuration type is invalid available choices are '${Constants.ELECTRUMX_TYPE}'`
         );
       }
     }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -621,6 +621,7 @@ class FiroConfig {
   electrumx?: {
     host: string;
     port: number;
+    reconnectDelay: number;
     timeout: number;
   };
 
@@ -638,8 +639,11 @@ class FiroConfig {
       } else if (this.type === Constants.ELECTRUMX_TYPE) {
         const host = getRequiredString('firo.electrumx.host');
         const port = getRequiredNumber('firo.electrumx.port');
+        const reconnectDelay = getRequiredNumber(
+          'firo.electrumx.reconnectDelay'
+        );
         const timeout = getRequiredNumber('firo.electrumx.timeout');
-        this.electrumx = { host, port, timeout };
+        this.electrumx = { host, port, reconnectDelay, timeout };
       } else {
         throw new Error(
           `Improperly configured. firo configuration type is invalid available choices are '${Constants.RPC_TYPE}', '${Constants.ELECTRUMX_TYPE}'`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,6 +5,7 @@ export const TRIGGER_EXTRACTOR_NAME = 'watcher-trigger-extractor';
 export const COLLATERAL_EXTRACTOR_NAME = 'watcher-collateral-extractor';
 export const ESPLORA_TYPE = 'esplora';
 export const RPC_TYPE = 'rpc';
+export const ELECTRUMX_TYPE = 'electrumx';
 export const EVM_RPC_TYPE = 'rpc';
 export const OGMIOS_TYPE = 'ogmios';
 export const KOIOS_TYPE = 'koios';

--- a/src/utils/healthCheck.ts
+++ b/src/utils/healthCheck.ts
@@ -9,7 +9,6 @@ import {
   NodePermitHealthCheckParam,
 } from '@rosen-bridge/permit-check';
 import {
-  FiroElectrumXScannerHealthCheck,
   ScannerSyncHealthCheckParam,
   CardanoOgmiosScannerHealthCheck,
 } from '@rosen-bridge/scanner-sync-check';
@@ -200,8 +199,7 @@ class HealthCheckSingleton {
     const currentConfig = getConfig();
     let scannerSyncCheck:
       | ScannerSyncHealthCheckParam
-      | CardanoOgmiosScannerHealthCheck
-      | FiroElectrumXScannerHealthCheck;
+      | CardanoOgmiosScannerHealthCheck;
     if (
       getConfig().general.networkWatcher === CARDANO_CHAIN_NAME &&
       getConfig().cardano.type === OGMIOS_TYPE
@@ -215,16 +213,6 @@ class HealthCheckSingleton {
         getConfig().healthCheck.scannerCriticalDiff,
         // TODO: Fix configuration: local/health-check/-/issues/29
         getConfig().cardano.ogmios!.connectionRetrialInterval * 15
-      );
-    } else if (currentConfig.general.networkWatcher === FIRO_CHAIN_NAME) {
-      scannerSyncCheck = new FiroElectrumXScannerHealthCheck(
-        this.observingNetworkLastBlock(scanner.getObservationScanner().name()),
-        currentConfig.healthCheck.scannerWarnDiff,
-        currentConfig.healthCheck.scannerCriticalDiff,
-        currentConfig.firo.electrumx!.host,
-        currentConfig.firo.electrumx!.port,
-        FIRO_BLOCK_TIME,
-        currentConfig.firo.interval
       );
     } else {
       let chainName: string;
@@ -251,15 +239,15 @@ class HealthCheckSingleton {
           chainBlockTime = DOGE_BLOCK_TIME;
           updateInterval = getConfig().doge.interval;
           break;
+        case FIRO_CHAIN_NAME:
+          chainName = FIRO_CHAIN_NAME;
+          chainBlockTime = FIRO_BLOCK_TIME;
+          updateInterval = currentConfig.firo.interval;
+          break;
         case ETHEREUM_CHAIN_NAME:
           chainName = ETHEREUM_CHAIN_NAME;
           chainBlockTime = ETHEREUM_BLOCK_TIME;
           updateInterval = getConfig().ethereum.interval;
-          break;
-        case FIRO_CHAIN_NAME:
-          chainName = FIRO_CHAIN_NAME;
-          chainBlockTime = FIRO_BLOCK_TIME;
-          updateInterval = getConfig().firo.interval;
           break;
         case BINANCE_CHAIN_NAME:
           chainName = BINANCE_CHAIN_NAME;

--- a/src/utils/healthCheck.ts
+++ b/src/utils/healthCheck.ts
@@ -9,6 +9,7 @@ import {
   NodePermitHealthCheckParam,
 } from '@rosen-bridge/permit-check';
 import {
+  FiroElectrumXScannerHealthCheck,
   ScannerSyncHealthCheckParam,
   CardanoOgmiosScannerHealthCheck,
 } from '@rosen-bridge/scanner-sync-check';
@@ -196,9 +197,11 @@ class HealthCheckSingleton {
    */
   registerScannerSyncHealthCheck = () => {
     const scanner = CreateScanner.getInstance();
+    const currentConfig = getConfig();
     let scannerSyncCheck:
       | ScannerSyncHealthCheckParam
-      | CardanoOgmiosScannerHealthCheck;
+      | CardanoOgmiosScannerHealthCheck
+      | FiroElectrumXScannerHealthCheck;
     if (
       getConfig().general.networkWatcher === CARDANO_CHAIN_NAME &&
       getConfig().cardano.type === OGMIOS_TYPE
@@ -212,6 +215,16 @@ class HealthCheckSingleton {
         getConfig().healthCheck.scannerCriticalDiff,
         // TODO: Fix configuration: local/health-check/-/issues/29
         getConfig().cardano.ogmios!.connectionRetrialInterval * 15
+      );
+    } else if (currentConfig.general.networkWatcher === FIRO_CHAIN_NAME) {
+      scannerSyncCheck = new FiroElectrumXScannerHealthCheck(
+        this.observingNetworkLastBlock(scanner.getObservationScanner().name()),
+        currentConfig.healthCheck.scannerWarnDiff,
+        currentConfig.healthCheck.scannerCriticalDiff,
+        currentConfig.firo.electrumx!.host,
+        currentConfig.firo.electrumx!.port,
+        FIRO_BLOCK_TIME,
+        currentConfig.firo.interval
       );
     } else {
       let chainName: string;
@@ -243,15 +256,15 @@ class HealthCheckSingleton {
           chainBlockTime = ETHEREUM_BLOCK_TIME;
           updateInterval = getConfig().ethereum.interval;
           break;
-        case BINANCE_CHAIN_NAME:
-          chainName = BINANCE_CHAIN_NAME;
-          chainBlockTime = BINANCE_BLOCK_TIME;
-          updateInterval = getConfig().binance.interval;
-          break;
         case FIRO_CHAIN_NAME:
           chainName = FIRO_CHAIN_NAME;
           chainBlockTime = FIRO_BLOCK_TIME;
           updateInterval = getConfig().firo.interval;
+          break;
+        case BINANCE_CHAIN_NAME:
+          chainName = BINANCE_CHAIN_NAME;
+          chainBlockTime = BINANCE_BLOCK_TIME;
+          updateInterval = getConfig().binance.interval;
           break;
       }
 

--- a/src/utils/networkConnectorManagers.ts
+++ b/src/utils/networkConnectorManagers.ts
@@ -15,7 +15,10 @@ import {
   EsploraNetwork,
   BitcoinEsploraTransaction,
 } from '@rosen-bridge/bitcoin-scanner';
-import { FiroRpcNetwork, FiroRpcTransaction } from '@rosen-bridge/firo-scanner';
+import {
+  FiroElectrumXNetwork,
+  FiroRpcTransaction,
+} from '@rosen-bridge/firo-scanner';
 import {
   KoiosNetwork,
   BlockFrostNetwork,
@@ -276,30 +279,27 @@ export const createEvmNetworkConnectorManager = (chainName: string) => {
 };
 
 /**
- * Creates and configures a NetworkConnectorManager instance for Firo RPC scanner
+ * Creates and configures a NetworkConnectorManager instance for Firo ElectrumX scanner
  */
-export const createFiroRpcNetworkConnectorManager = () => {
+export const createFiroElectrumXNetworkConnectorManager = () => {
   const networkConnectorManager =
     new NetworkConnectorManager<FiroRpcTransaction>(
       new FailoverStrategy(),
       firoLogger
     );
 
-  if (config.firo.rpc) {
+  if (config.firo.electrumx) {
     networkConnectorManager.addConnector(
-      new FiroRpcNetwork(
-        config.firo.rpc.url,
-        config.firo.rpc.timeout * 1000,
-        config.firo.rpc.username && config.firo.rpc.password
-          ? {
-              username: config.firo.rpc.username,
-              password: config.firo.rpc.password,
-            }
-          : undefined
+      new FiroElectrumXNetwork(
+        config.firo.electrumx.host,
+        config.firo.electrumx.port,
+        config.firo.electrumx.timeout * 1000
       )
     );
   } else {
-    throw new Error('Rpc configuration must be provided for Firo Rpc network');
+    throw new Error(
+      'ElectrumX configuration must be provided for Firo ElectrumX network'
+    );
   }
 
   return networkConnectorManager;

--- a/src/utils/networkConnectorManagers.ts
+++ b/src/utils/networkConnectorManagers.ts
@@ -17,6 +17,7 @@ import {
 } from '@rosen-bridge/bitcoin-scanner';
 import {
   FiroElectrumXNetwork,
+  FiroRpcNetwork,
   FiroRpcTransaction,
 } from '@rosen-bridge/firo-scanner';
 import {
@@ -273,6 +274,36 @@ export const createEvmNetworkConnectorManager = (chainName: string) => {
     );
   } else {
     throw new Error(`No RPC configuration found for ${chainName}`);
+  }
+
+  return networkConnectorManager;
+};
+
+/**
+ * Creates and configures a NetworkConnectorManager instance for Firo RPC scanner
+ */
+export const createFiroRpcNetworkConnectorManager = () => {
+  const networkConnectorManager =
+    new NetworkConnectorManager<FiroRpcTransaction>(
+      new FailoverStrategy(),
+      firoLogger
+    );
+
+  if (config.firo.rpc) {
+    networkConnectorManager.addConnector(
+      new FiroRpcNetwork(
+        config.firo.rpc.url,
+        config.firo.rpc.timeout * 1000,
+        config.firo.rpc.username && config.firo.rpc.password
+          ? {
+              username: config.firo.rpc.username,
+              password: config.firo.rpc.password,
+            }
+          : undefined
+      )
+    );
+  } else {
+    throw new Error('Rpc configuration must be provided for Firo Rpc network');
   }
 
   return networkConnectorManager;

--- a/src/utils/networkConnectorManagers.ts
+++ b/src/utils/networkConnectorManagers.ts
@@ -324,7 +324,8 @@ export const createFiroElectrumXNetworkConnectorManager = () => {
       new FiroElectrumXNetwork(
         config.firo.electrumx.host,
         config.firo.electrumx.port,
-        config.firo.electrumx.timeout * 1000
+        config.firo.electrumx.reconnectDelay,
+        config.firo.electrumx.timeout
       )
     );
   } else {

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -43,9 +43,9 @@ import {
   BinanceRpcObservationExtractor,
   EthereumRpcObservationExtractor,
 } from '@rosen-bridge/evm-observation-extractor';
-import { FiroRpcObservationExtractor } from '@rosen-bridge/firo-observation-extractor';
-import { FiroRpcScanner } from '@rosen-bridge/firo-scanner';
 import { EvmRpcScanner } from '@rosen-bridge/evm-scanner';
+import { FiroObservationExtractor } from '@rosen-bridge/firo-observation-extractor';
+import { FiroElectrumXScanner } from '@rosen-bridge/firo-scanner';
 import { dataSource } from '../../config/dataSource';
 import {
   BinanceConfig,
@@ -69,9 +69,9 @@ import {
   createDogeEsploraNetworkConnectorManager,
   createDogeRpcNetworkConnectorManager,
   createEvmNetworkConnectorManager,
-  createFiroRpcNetworkConnectorManager,
   createErgoNodeNetworkConnectorManager,
   createErgoExplorerNetworkConnectorManager,
+  createFiroElectrumXNetworkConnectorManager,
 } from './networkConnectorManagers';
 
 const logger = DefaultLogger.getInstance().child(import.meta.url);
@@ -106,7 +106,7 @@ class CreateScanner {
     | DogeEsploraScanner
     | DogeRpcScanner
     | EvmRpcScanner
-    | FiroRpcScanner;
+    | FiroElectrumXScanner;
 
   private constructor() {
     // do nothing
@@ -225,7 +225,7 @@ class CreateScanner {
     | DogeEsploraScanner
     | DogeRpcScanner
     | EvmRpcScanner
-    | FiroRpcScanner => {
+    | FiroElectrumXScanner => {
     if (!CreateScanner.instance) {
       throw new Error('Scanner is not initialized');
     }
@@ -592,15 +592,15 @@ class CreateScanner {
     observationStoreRawData: boolean
   ) => {
     if (!this.observationScanner) {
-      if (firoConfig.rpc) {
-        this.observationScanner = new FiroRpcScanner({
+      if (firoConfig.electrumx) {
+        this.observationScanner = new FiroElectrumXScanner({
           dataSource,
           initialHeight: firoConfig.initialHeight,
-          network: createFiroRpcNetworkConnectorManager(),
+          network: createFiroElectrumXNetworkConnectorManager(),
           logger: loggers.observationScannerLogger,
         });
 
-        const observationExtractor = new FiroRpcObservationExtractor(
+        const observationExtractor = new FiroObservationExtractor(
           rosenConfig.lockAddress,
           dataSource,
           TokensConfig.getInstance().getTokenMap(),

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -44,8 +44,14 @@ import {
   EthereumRpcObservationExtractor,
 } from '@rosen-bridge/evm-observation-extractor';
 import { EvmRpcScanner } from '@rosen-bridge/evm-scanner';
-import { FiroObservationExtractor } from '@rosen-bridge/firo-observation-extractor';
-import { FiroElectrumXScanner } from '@rosen-bridge/firo-scanner';
+import {
+  FiroObservationExtractor,
+  FiroRpcObservationExtractor,
+} from '@rosen-bridge/firo-observation-extractor';
+import {
+  FiroElectrumXScanner,
+  FiroRpcScanner,
+} from '@rosen-bridge/firo-scanner';
 import { dataSource } from '../../config/dataSource';
 import {
   BinanceConfig,
@@ -72,6 +78,7 @@ import {
   createErgoNodeNetworkConnectorManager,
   createErgoExplorerNetworkConnectorManager,
   createFiroElectrumXNetworkConnectorManager,
+  createFiroRpcNetworkConnectorManager,
 } from './networkConnectorManagers';
 
 const logger = DefaultLogger.getInstance().child(import.meta.url);
@@ -106,6 +113,7 @@ class CreateScanner {
     | DogeEsploraScanner
     | DogeRpcScanner
     | EvmRpcScanner
+    | FiroRpcScanner
     | FiroElectrumXScanner;
 
   private constructor() {
@@ -225,6 +233,7 @@ class CreateScanner {
     | DogeEsploraScanner
     | DogeRpcScanner
     | EvmRpcScanner
+    | FiroRpcScanner
     | FiroElectrumXScanner => {
     if (!CreateScanner.instance) {
       throw new Error('Scanner is not initialized');
@@ -592,7 +601,23 @@ class CreateScanner {
     observationStoreRawData: boolean
   ) => {
     if (!this.observationScanner) {
-      if (firoConfig.electrumx) {
+      if (firoConfig.rpc) {
+        this.observationScanner = new FiroRpcScanner({
+          dataSource,
+          initialHeight: firoConfig.initialHeight,
+          network: createFiroRpcNetworkConnectorManager(),
+          logger: loggers.observationScannerLogger,
+        });
+
+        const observationExtractor = new FiroRpcObservationExtractor(
+          rosenConfig.lockAddress,
+          dataSource,
+          TokensConfig.getInstance().getTokenMap(),
+          loggers.observationExtractorLogger,
+          observationStoreRawData
+        );
+        this.observationScanner.registerExtractor(observationExtractor);
+      } else if (firoConfig.electrumx) {
         this.observationScanner = new FiroElectrumXScanner({
           dataSource,
           initialHeight: firoConfig.initialHeight,


### PR DESCRIPTION
This PR ports the watcher’s Firo path from firod RPC to ElectrumX by replacing the Firo RPC connector/scanner wiring with FiroElectrumXNetwork, FiroElectrumXScanner, FiroObservationExtractor, and the Firo ElectrumX scanner health check, while updating config/env names from firo.rpc to firo.electrumx. 

Note: Watcher depends on new ElectrumX exports from the scanner and health-check packages, so this PR can only pass install/tests after those PRs are merged, released, and the watcher lockfile is updated to consume the new package versions.